### PR TITLE
Restore inline style in search form - matches top-left search

### DIFF
--- a/404.md
+++ b/404.md
@@ -4,4 +4,10 @@ permalink: /404.html
 sitemap: false
 ---
 
-This page doesn't exist!
+We could not find the help page you requested.
+
+<form action="/duckduckgo-help-pages/search/" method="get">
+  <input type="text" name="q" id="search-input" placeholder="Search" autofocus="">
+  <input type="submit" value="Search" style="display: none;">
+</form>
+

--- a/index.md
+++ b/index.md
@@ -6,6 +6,6 @@ Welcome to DuckDuckGo Help - If you can't find an answer to your DuckDuckGo ques
 
 <form action="/duckduckgo-help-pages/search/" method="get">
   <input type="text" name="q" id="search-input" placeholder="Search" autofocus="">
-  <input type="submit" value="Search">
+  <input type="submit" value="Search" style="display: none;">
 </form>
 


### PR DESCRIPTION
Yikes... Let's nix the button
![yikes](https://user-images.githubusercontent.com/444449/54274812-00524480-4581-11e9-805c-56ce636ca191.png)
