### PR TITLE
Fix Strayed End Tag in Document

### DIFF
--- a/_docs/features/instant-answers-and-other-features.md
+++ b/_docs/features/instant-answers-and-other-features.md
@@ -15,7 +15,7 @@ order: 699
 
 <img src="{{ site.baseurl }}/images/411bc9a9495387e1124d3721b7befe7b.png" />
 <p>
-    They're open source, so any developer can view them or submit fixes through our <a href="https://github.com/duckduckgo">GitHub repository</a>. This also means we have a wide variety of Instant Answers!</a>
+    They're open source, so any developer can view them or submit fixes through our <a href="https://github.com/duckduckgo">GitHub repository</a>. This also means we have a wide variety of Instant Answers!
 </p>
 
 <p>


### PR DESCRIPTION
Hello.
I fixed strayed end tag (tag `</a>` which has no start tag `<a ...>`) in the document for “[Instant Answers and Other Features](/duckduckgo/duckduckgo-help-pages/blob/fb16761b2bc5afa30f596fa7aad508b805d739e0/_docs/features/instant-answers-and-other-features.md).”

If there is no problem, would you please marge it?