### PR TITLE
Update Copyright Year to 2020

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,7 +71,7 @@
 
             <footer class="footer">
                 <div class="content">
-                    <section class="copyright">DuckDuckGo © 2019</section>
+                    <section class="copyright">DuckDuckGo © 2020</section>
                     <div class="footer__nav">
                         <a href="https://duckduckgo.com/" target="_blank">Search</a>
                         <span class="footer__nav__sep"></span>


### PR DESCRIPTION
Hello,

I am assuming DuckDuckGo's Copyright extends to 2020, if so, this year should be updated.