### PR TITLE
update usage of `Share Feedback`

### DIFF
--- a/_docs/company/contact-us.md
+++ b/_docs/company/contact-us.md
@@ -13,7 +13,7 @@ order: 282
 - If you find any malware, phishing, or suspicious-looking websites or ads on DuckDuckGo, report them at [abuse@duckduckgo.com](mailto:abuse@duckduckgo.com).
 - For security vulnerabilities, submit a report via [HackerOne](https://hackerone.com/duckduckgo).
 - If you wish to add or update a !bang, use the [!bang submission form](https://duckduckgo.com/newbang).
-- For feedback regarding DuckDuckGo Search, use the "Send feedback" link in the side of the results pages.
+- For feedback regarding DuckDuckGo Search, use the <em>Share Feedback</em> link at the bottom of the results pages.
 - If you have general queries that don’t fall into the categories above, we’re listening at [open@duckduckgo.com](mailto:open@duckduckgo.com).
 
 - Our mailing address is 20 Paoli Pike, Paoli, Pennsylvania 19301, USA.

--- a/_docs/features/dates.md
+++ b/_docs/features/dates.md
@@ -34,8 +34,8 @@ order: 716
 </p>
 
 <p>
-    We're monitoring comments that we receive from the "Send feedback" button on
-    desktop, so feel free to let us know how it's working for you. We listen!
+    We're monitoring comments that we receive from the <em>"Share Feedback"</em> button,
+    so feel free to let us know how it's working for you. We listen!
 </p>
 
 <p>

--- a/_docs/features/safe-search.md
+++ b/_docs/features/safe-search.md
@@ -41,8 +41,8 @@ order: 721
 <p>
     We try hard to respect your safe search preference, but sometimes content does
     get through that is not appropriately restricted. If you notice this
-    happening, we'd appreciate you letting us know via the "Send feedback" button
-    on the right-hand side of our search results (on desktop), and we'll do our
+    happening, we'd appreciate you letting us know via the <em>"Share Feedback"</em> button
+    in the bottom right-hand corner of our search results (on desktop), and we'll do our
     best to resolve it in a timely fashion.
 </p>
 

--- a/_docs/results/spam.md
+++ b/_docs/results/spam.md
@@ -5,9 +5,8 @@ order: 415
 ---
 
 <p>
-    Please use the <em>Feedback</em> link in the menu sidebar to report any spam
-    or bad relevancy. The menu can be accessed by clicking on the menu icon (three
-    horizontal lines) at the top-right of our pages.
+    Please use the <em>Share Feedback</em> button at the bottom of the search Results
+    to report any spam or bad relevancy.
 </p>
 
 <p>


### PR DESCRIPTION
- Location of the `Share Feedback` button has moved the bottom right-hand on desktop and bottom center on mobile.
- Text has changed from `Send feedback` to `Share Feedback`