### PR TITLE
Unpublish search syntax help page

### DIFF
--- a/_docs/results/syntax.md
+++ b/_docs/results/syntax.md
@@ -2,6 +2,7 @@
 title: DuckDuckGo Search Syntax
 category: Results
 order: 401
+published: false
 ---
 
 <p>DuckDuckGo supports search syntax you can use to fine-tune your queries.</p>


### PR DESCRIPTION
This PR removes the syntax help page from the published site.