### PR TITLE
Prevent translations from appearing in search results

### DIFF
--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-bg_BG.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-bg_BG.md
@@ -2,6 +2,7 @@
 title: Реклами от Microsoft при Частно търсене с DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 800
+excluded_in_search: true
 ---
 
 **Вашата поверителност при гледане на реклами е защитена от DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-cs_CZ.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-cs_CZ.md
@@ -2,6 +2,7 @@
 title: Reklamy společnosti Microsoft v soukromém vyhledávání společnosti DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 801
+excluded_in_search: true
 ---
 
 **Při zobrazení reklam společnost DuckDuckGo chrání vaše soukromí.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-da_DK.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-da_DK.md
@@ -2,6 +2,7 @@
 title: Annoncer fra Microsoft på DuckDuckGo privat søgning
 category: Translated Microsoft Ads Notice
 order: 802
+excluded_in_search: true
 ---
 
 **DuckDuckGo beskytter dine personoplysninger, når du ser annoncer.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-de_DE.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-de_DE.md
@@ -2,6 +2,7 @@
 title: Anzeigen von Microsoft auf DuckDuckGo Private Search
 category: Translated Microsoft Ads Notice
 order: 803
+excluded_in_search: true
 ---
 
 **Der Datenschutz beim Aufrufen von Anzeigen wird durch DuckDuckGo gewährleistet.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-el_GR.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-el_GR.md
@@ -2,6 +2,7 @@
 title: Διαφημίσεις της Microsoft στην Ιδιωτική Αναζήτηση DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 804
+excluded_in_search: true
 ---
 
 **Στην προβολή διαφημίσεων υπάρχει προστασία απορρήτου από την DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-es_ES.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-es_ES.md
@@ -2,6 +2,7 @@
 title: Anuncios de Microsoft en las búsquedas privadas de DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 805
+excluded_in_search: true
 ---
 
 **DuckDuckGo protege la privacidad de la visualización de anuncios.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-et_EE.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-et_EE.md
@@ -2,6 +2,7 @@
 title: Microsofti reklaamid DuckDuckGo privaatses otsingus
 category: Translated Microsoft Ads Notice
 order: 806
+excluded_in_search: true
 ---
 
 **DuckDuckGo kaitseb reklaamide vaatamisel teie privaatsust.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-fi_FI.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-fi_FI.md
@@ -2,6 +2,7 @@
 title: Microsoftin mainokset DuckDuckGo:n yksityisessä haussa
 category: Translated Microsoft Ads Notice
 order: 807
+excluded_in_search: true
 ---
 
 **Mainosten katselu on DuckDuckGo:n tietosuojaama.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-fr_FR.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-fr_FR.md
@@ -2,6 +2,7 @@
 title: Annonces de Microsoft sur DuckDuckGo Private Search
 category: Translated Microsoft Ads Notice
 order: 808
+excluded_in_search: true
 ---
 
 **La confidentialité des annonces est protégée par DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-hr_HR.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-hr_HR.md
@@ -2,6 +2,7 @@
 title: Microsoftovi oglasi na DuckDuckGo Private Search
 category: Translated Microsoft Ads Notice
 order: 809
+excluded_in_search: true
 ---
 
 **Pregledavanje oglasa je privatnost koju štiti DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-hu_HU.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-hu_HU.md
@@ -2,6 +2,7 @@
 title: Microsoft által megjelenített hirdetések a DuckDuckGo privát keresőben
 category: Translated Microsoft Ads Notice
 order: 810
+excluded_in_search: true
 ---
 
 **A hirdetéseket a DuckDuckGo adatvédelme keretében tekintheted meg.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-is_IS.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-is_IS.md
@@ -2,6 +2,7 @@
 title: Auglýsingar frá Microsoft á DuckDuckGo einkaleit
 category: Translated Microsoft Ads Notice
 order: 811
+excluded_in_search: true
 ---
 
 **Að skoða auglýsingar fellur undir persónuvernd frá DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-it_IT.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-it_IT.md
@@ -2,6 +2,7 @@
 title: Annunci di Microsoft sulla Ricerca privata di DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 812
+excluded_in_search: true
 ---
 
 **La privacy della visualizzazione degli annunci è protetta da DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-lt_LT.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-lt_LT.md
@@ -2,6 +2,7 @@
 title: „„Microsoft“ skelbimai „DuckDuckGo“ privačioje paieškoje
 category: Translated Microsoft Ads Notice
 order: 813
+excluded_in_search: true
 ---
 
 **Peržiūrimų skelbimų privatumą saugo „DuckDuckGo“.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-lu_LU.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-lu_LU.md
@@ -2,6 +2,7 @@
 title: Annoncen duerch Microsoft op DuckDuckGo Private Search
 category: Translated Microsoft Ads Notice
 order: 814
+excluded_in_search: true
 ---
 
 **D'Uweise vun Annoncen ass duerch d'Dateschutzpolitik vun DuckDuckGo geschützt.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-lv_LV.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-lv_LV.md
@@ -2,6 +2,7 @@
 title: Microsoft reklāmas DuckDuckGo privātajā meklēšanā
 category: Translated Microsoft Ads Notice
 order: 815
+excluded_in_search: true
 ---
 
 **Reklāmu skatīšanu aizsargā DuckDuckGo konfidencialitāte.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-nb_NO.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-nb_NO.md
@@ -2,6 +2,7 @@
 title: Annonser gjennom Microsoft på DuckDuckGos private søk
 category: Translated Microsoft Ads Notice
 order: 816
+excluded_in_search: true
 ---
 
 **Visningsannonser er personvernbeskyttet av DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-nl_NL.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-nl_NL.md
@@ -2,6 +2,7 @@
 title: Advertenties van Microsoft in DuckDuckGo Private Search
 category: Translated Microsoft Ads Notice
 order: 817
+excluded_in_search: true
 ---
 
 **De weergave van advertenties wordt beschermd door DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-pl_PL.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-pl_PL.md
@@ -2,6 +2,7 @@
 title: Reklamy firmy Microsoft w chroniącej prywatność wyszukiwarce DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 818
+excluded_in_search: true
 ---
 
 **DuckDuckGo chroni prywatność użytkowników przeglądających reklamy.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-pt_PT.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-pt_PT.md
@@ -2,6 +2,7 @@
 title: Anúncios da Microsoft na Pesquisa Privada DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 819
+excluded_in_search: true
 ---
 
 **A visualização de anúncios tem proteção de privacidade pelo DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-ro_RO.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-ro_RO.md
@@ -2,6 +2,7 @@
 title: Reclame de la Microsoft în funcția de căutare privată DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 820
+excluded_in_search: true
 ---
 
 **Vizualizarea reclamelor este protejată de confidențialitatea DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-ru_RU.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-ru_RU.md
@@ -2,6 +2,7 @@
 title: Рекламные объявления Microsoft в конфиденциальном поиске DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 821
+excluded_in_search: true
 ---
 
 **DuckDuckGo обеспечивает защиту конфиденциальности пользователей при просмотре рекламных объявлений.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-sk_SK.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-sk_SK.md
@@ -2,6 +2,7 @@
 title: Reklamy od spoločnosti Microsoft v súkromnom vyhľadávaní DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 822
+excluded_in_search: true
 ---
 
 **Zobrazenie reklám je chránené ochranou osobných údajov DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-sl_SL.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-sl_SL.md
@@ -2,6 +2,7 @@
 title: Microsoftovi oglasi pri zasebnem iskanju z DuckDuckGo
 category: Translated Microsoft Ads Notice
 order: 823
+excluded_in_search: true
 ---
 
 **DuckDuckGo ščiti vašo zasebnost pri ogledu oglasov.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-sv_SE.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-sv_SE.md
@@ -2,6 +2,7 @@
 title: Annonser från Microsoft på DuckDuckGo Privat sökning
 category: Translated Microsoft Ads Notice
 order: 824
+excluded_in_search: true
 ---
 
 **Visning av annonser är sekretessskyddat av DuckDuckGo.**

--- a/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-tr_TR.md
+++ b/_docs/translated/ads-by-microsoft-on-duckduckgo-private-search-tr_TR.md
@@ -2,6 +2,7 @@
 title: DuckDuckGo Gizli Arama sayfalarında Microsoft tarafından yayınlanan reklamlar
 category: Translated Microsoft Ads Notice
 order: 825
+excluded_in_search: true
 ---
 
 **Reklam görüntüleme, DuckDuckGo'nun gizlilik koruması altındadır.**


### PR DESCRIPTION
To test this PR: 
- Search for 'microsoft'

You should not see any translated pages in the results.