### PR TITLE
Update other browers list

### DIFF
--- a/_docs/desktop/other-browsers.md
+++ b/_docs/desktop/other-browsers.md
@@ -9,26 +9,22 @@ order: 15
 <ul>
     <li><a href="https://adblockbrowser.org/">Adblock Browser</a></li>
     <li><a href="https://brave.com/">Brave</a></li>
-    <li><a href="http://crportable.sourceforge.net/">Chromium Portable</a></li>
-    <li><a href="http://conkeror.org/">Conkeror</a></li>
     <li><a href="https://www.dillo.org/">Dillo</a></li>
-    <li><a href="http://dooble.sourceforge.net/">Dooble</a></li>
-    <li><a href="http://www.gnu.org/software/gnuzilla/">GNU Icecat</a></li>
-    <li><a href="http://kmeleon.sourceforge.net/">K-Meleon</a></li>
-    <li><a href="https://konqueror.org/">Konqueror</a></li>
+    <li><a href="https://textbrowser.github.io/dooble/">Dooble</a></li>
+    <li><a href="https://www.gnu.org/software/gnuzilla/">GNU Icecat</a></li>
+    <li><a href="https://apps.kde.org/konqueror/">Konqueror</a></li>
     <li><a href="https://otter-browser.org/">Otter Browser</a></li>
-    <li><a href="http://twotoasts.de/index.php/midori/">Midori</a></li>
-    <li><a href="https://minbrowser.github.io/min/">Min</a></li>
+    <li><a href="https://astian.org/midori-browser/">Midori</a></li>
+    <li><a href="https://minbrowser.org/">Min</a></li>
     <li><a href="https://www.omnigroup.com/more/">OmniWeb</a></li>
-    <li><a href="http://www.palemoon.org/">Pale Moon</a></li>
+    <li><a href="https://www.palemoon.org/">Pale Moon</a></li>
     <li><a href="https://www.seamonkey-project.org/">SeaMonkey</a></li>
-    <li><a href="http://www.slimjet.com/">Slimjet</a></li>
-    <li><a href="http://www.srware.net/en/software_srware_iron.php">SRWare Iron</a></li>
-    <li><a href="https://www.torproject.org/torbutton/">Torbutton</a> (captcha
-        default)</li>
+    <li><a href="https://www.slimjet.com/">Slimjet</a></li>
+    <li><a href="https://www.srware.net/iron/">SRWare Iron</a></li>
+    <li><a href="https://www.torproject.org/de/download/">Tor Browser</a></li>
     <li><a href="https://sourceforge.net/projects/vimprobable/">Vimprobable</a></li>
     <li><a href="https://vivaldi.com">Vivaldi</a></li>
-    <li><a href="https://www.waterfoxproject.org/">Waterfox</a></li>
+    <li><a href="https://www.waterfox.net/">Waterfox</a></li>
 </ul>
 <p>
     We could really use your help in getting in more browsers. Please send an


### PR DESCRIPTION
Here is a small update of the other browsers list

1. followed 301 redirects http -> https
2. followed 301 redirects to new pages
3. replaced obsolete browsers by their successors
    -  Dooble -> next-generation Dooble
    - Torbutton -> Tor Browser
4. removed discontinued browsers (latest release years ago)
    - Chromium Portable
    - Conkeror