### PR TITLE
Update linux distributions list

### DIFF
--- a/_docs/desktop/linux-distributions.md
+++ b/_docs/desktop/linux-distributions.md
@@ -7,36 +7,33 @@ order: 72
 <p>The following Linux distributions include DuckDuckGo as a search option.</p>
 
 <ul>
-    <li><a href="http://www.backbox.org/">BackBox</a></li>
-    <li><a href="http://bodhilinux.com/">Bodhi Linux</a></li>
-    <li><a href="http://www.debian.org/">Debian</a></li>
-    <li><a href="http://doudoulinux.org/web/english/index.html">Doudou Linux</a></li>
-    <li><a href="http://elementaryos.org/">elementary OS</a></li>
-    <li><a href="http://fedoraproject.org/">Fedora</a></li>
-    <li><a href="http://www.freebsd.org/">FreeBSD</a></li>
+    <li><a href="https://www.backbox.org/">BackBox</a></li>
+    <li><a href="https://www.bodhilinux.com/">Bodhi Linux</a></li>
+    <li><a href="https://www.debian.org/">Debian</a></li>
+    <li><a href="https://www.doudoulinux.org/web/english/index.html">Doudou Linux</a></li>
+    <li><a href="https://elementary.io/">elementary OS</a></li>
+    <li><a href="https://getfedora.org/">Fedora</a></li>
+    <li><a href="https://www.freebsd.org/">FreeBSD</a></li>
     <li><a href="http://ghostbsd.org/">GhostBSD</a></li>
-    <li><a href="http://kde.org/">KDE</a></li>
-    <li><a href="http://www.kubuntu.org/">Kubuntu</a></li>
-    <li><a href="http://www.linuxmint.com/">Linux Mint</a></li>
-    <li><a href="http://luninuxos.com/">LuninuX OS</a></li>
-    <li><a href="http://www.lxle.net">LXLE</a></li>
-    <li><a href="http://www.mageia.org/en/">Mageia</a></li>
-    <li><a href="http://openmoko.com/">Openmoko</a></li>
-    <li><a href="http://www.opensuse.org/">openSUSE</a></li>
-    <li><a href="http://peppermintos.com/">Peppermint</a></li>
+    <li><a href="https://kde.org/">KDE</a></li>
+    <li><a href="https://kubuntu.org/">Kubuntu</a></li>
+    <li><a href="https://www.linuxmint.com/">Linux Mint</a></li>
+    <li><a href="https://luninuxos.com/">LuninuX OS</a></li>
+    <li><a href="https://www.lxle.net/">LXLE</a></li>
+    <li><a href="https://www.mageia.org/en/">Mageia</a></li>
+    <li><a href="https://wiki.openmoko.org/wiki/Main_Page">Openmoko</a></li>
+    <li><a href="https://www.opensuse.org/">openSUSE</a></li>
+    <li><a href="https://peppermintos.com/">Peppermint</a></li>
     <li><a href="http://porteus.org/">Porteus</a></li>
     <li><a href="https://www.pureos.net/">PureOS</a></li>
-    <li><a href="http://www.raspberrypi.org/">Raspberry Pi</a></li>
-    <li><a href="https://www.redhat.com/">Red Hat</a></li>
-    <li><a href="http://www.salixos.org/">Salix OS</a></li>
-    <li><a href="http://www.slitaz.org/en/">SliTaz</a></li>
-    <li><a href="https://www.snowlinux.de/">Snowlinux</a></li>
-    <li><a href="http://www.sysresccd.org/SystemRescueCd_Homepage">SystemRescueCd</a></li>
-    <li><a href="http://trisquel.info/">Trisquel</a></li>
+    <li><a href="https://www.raspberrypi.org/">Raspberry Pi</a></li>
+    <li><a href="https://www.redhat.com/en">Red Hat</a></li>
+    <li><a href="https://www.salixos.org/">Salix OS</a></li>
+    <li><a href="https://www.slitaz.org/en/">SliTaz</a></li>
+    <li><a href="https://www.system-rescue.org/">SystemRescue</a></li>
+    <li><a href="https://trisquel.info/">Trisquel</a></li>
     <li><a href="http://uberstudent.org/">UberStudent</a></li>
-    <li><a href="http://www.ubuntu.com/">Ubuntu (Canonical)</a></li>
-    <li><a href="http://webconverger.com/">Webconverger</a></li>
-    <li><a href="http://www.zevenos.com/">ZevenOS</a></li>
+    <li><a href="https://ubuntu.com/">Ubuntu (Canonical)</a></li>
 </ul>
 <p>
     We could really use your help in getting in more distros. Please send an email


### PR DESCRIPTION
Noticed some outdated links in the linux distributions list.

Updated the links to it's permanent redirect destination and also removed discontinued distributions.