### PR TITLE
Redirect broken link

### DIFF
--- a/_docs/results/report-copyright-or-trademark-infringement.md
+++ b/_docs/results/report-copyright-or-trademark-infringement.md
@@ -1,0 +1,4 @@
+---
+layout: redirect
+redirect: /r-legal/report-copyright-or-trademark-infringement
+---


### PR DESCRIPTION
Temporarily redirect a broken link to the Report Copyright or Trademark Infringement page