### PR TITLE
Fix Email Protection supported browser URL

### DIFF
--- a/_docs/email-protection/how-do-i-enable-duckduckgo-email-protection-desktop.md
+++ b/_docs/email-protection/how-do-i-enable-duckduckgo-email-protection-desktop.md
@@ -6,4 +6,4 @@ category: DuckDuckGo Email Protection
 order: 300
 ---
 
-Visit [https://duckduckgo.com/email/login](https://duckduckgo.com/email/login) in a [supported browser](https://help.duckduckgo.com/how-do-i-get-duckduckgo-email-protection), and you'll be prompted to sign in. Follow the prompts to enable DuckDuckGo Email Protection so you can automatically autofill your personal Duck Address in online forms and generate new private Duck Addresses on the fly.
+Visit [https://duckduckgo.com/email/login](https://duckduckgo.com/email/login) in a [supported browser](https://help.duckduckgo.com/email-protection/how-do-i-get-duckduckgo-email-protection), and you'll be prompted to sign in. Follow the prompts to enable DuckDuckGo Email Protection so you can automatically autofill your personal Duck Address in online forms and generate new private Duck Addresses on the fly.


### PR DESCRIPTION
Spotted this URL is 404 as it's missing the `email-protection` prefix