### PR TITLE
Update referrer tracking protection for MV3 extension on Chrome + clarity around search term privacy

### DIFF
--- a/_docs/privacy/web-tracking-protections.md
+++ b/_docs/privacy/web-tracking-protections.md
@@ -156,10 +156,12 @@ When content loads in a web browser, the browser and any servers through which t
 
 By default, we “trim” (remove) some of the metadata in the “referrer header” that trackers could potentially use to track you individually. All 3rd-party requests are trimmed down to the hostname (for example, `info.test.com/path?query` becomes just `info.test.com`). We may make a [limited exception][remotely-configured-exceptions] when this protection would prevent you from signing in to a site or to otherwise preserve essential site functionality.
 
+Please note that even in the absence of this feature, your search terms are never sent to sites you click on from the DuckDuckGo Search results page. You can learn more [about Search Privacy][search-terms-privacy-rduckduckgocom].
+
 | Platform          | Support                                                                                                                                                                                                            |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Firefox extension | Referrer headers trimmed to the hostname for all requests originating from a different domain.                                                                                                                     |
-| Chrome extension  | Referrer headers trimmed to the hostname for all requests originating from a different domain.                                                                                                                     |
+| Chrome extension  | Unsupported due to [platform limitations][chromium-mv3-referrer-bug].                                                                                                                     |
 | Edge extension    | Unsupported due to [platform limitations][chromium-mv3-referrer-bug].                                                                                                                                              |
 | Opera extension   | Referrer headers trimmed to the hostname for all requests originating from a different domain.                                                                                                                     |
 | Safari extension  | Referrer headers trimmed to the hostname for all requests originating from a different domain than the visited site through WebKit’s [built-in referrer tracking protection][webkit-referrer-tracking-protection]. |
@@ -395,6 +397,7 @@ For questions, comments, or concerns, please feel free to <a href="{{ site.baseu
 [duckduckgo-private-search-ads]: #duckduckgo-private-search-ads
 [//]: # "Other help pages"
 [ads-by-microsoft]: https://help.duckduckgo.com/company/ads-by-microsoft-on-duckduckgo-private-search
+[search-terms-privacy-rduckduckgocom]: https://help.duckduckgo.com/results/rduckduckgocom
 [//]: # "Spread Privacy blog post links"
 [post-tracker-radar]: https://spreadprivacy.com/duckduckgo-tracker-radar/
 [post-private-ad-conversions]: https://spreadprivacy.com/more-privacy-and-transparency/

--- a/_docs/privacy/web-tracking-protections.md
+++ b/_docs/privacy/web-tracking-protections.md
@@ -156,7 +156,7 @@ When content loads in a web browser, the browser and any servers through which t
 
 By default, we “trim” (remove) some of the metadata in the “referrer header” that trackers could potentially use to track you individually. All 3rd-party requests are trimmed down to the hostname (for example, `info.test.com/path?query` becomes just `info.test.com`). We may make a [limited exception][remotely-configured-exceptions] when this protection would prevent you from signing in to a site or to otherwise preserve essential site functionality.
 
-Please note that even in the absence of this feature, your search terms are never sent to sites you click on from the DuckDuckGo Search results page. You can learn more [about Search Privacy][search-terms-privacy-rduckduckgocom].
+Please note that even in the absence of this feature, your DuckDuckGo search terms are never included in the referrer header. [Read more][search-terms-privacy-rduckduckgocom].
 
 | Platform          | Support                                                                                                                                                                                                            |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Our Chrome extension migration to MV3 is now completely released, so updating referrer tracking information to correspond. Also added a note to clarify that we never send search terms to sites clicked on from our SERP through the referer header.

**Asana:**
https://app.asana.com/0/1202899525821663/1207140330481303/f
https://app.asana.com/0/1202899525821663/1207132738656615/f